### PR TITLE
pkg_resources => importlib

### DIFF
--- a/pycnv/pycnv.py
+++ b/pycnv/pycnv.py
@@ -4,7 +4,11 @@ import numpy
 import logging
 import sys
 import argparse
-import pkg_resources
+
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import yaml
 import pylab as pl
 import os
@@ -12,10 +16,19 @@ import hashlib
 import errno
 import locale
 
-standard_name_file = pkg_resources.resource_filename('pycnv', 'rules/standard_names.yaml')
+try:
+    with importlib_resources.path("pycnv", "rules/standard_names.yaml") as p:
+        standard_name_file = str(p)
+except Exception:
+    standard_name_file = os.path.join(
+        os.path.dirname(__file__), "rules", "standard_names.yaml"
+    )
 
-# Get the version
-version_file = pkg_resources.resource_filename('pycnv','VERSION')
+try:
+    with importlib_resources.path("pycnv", "VERSION") as p:
+        version_file = str(p)
+except Exception:
+    version_file = os.path.join(os.path.dirname(__file__), "VERSION")
 
 with open(version_file) as version_f:
    version = version_f.read().strip()

--- a/pycnv/pycnv_sum_folder.py
+++ b/pycnv/pycnv_sum_folder.py
@@ -8,14 +8,22 @@ import sys
 import numpy
 import argparse
 import logging
-import pkg_resources
+
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import yaml
 from pytz import timezone
 import datetime
 
 
 # Get the version
-version_file = pkg_resources.resource_filename('pycnv','VERSION')
+try:
+    with importlib_resources.path("pycnv", "VERSION") as p:
+        version_file = str(p)
+except Exception:
+    version_file = os.path.join(os.path.dirname(__file__), "VERSION")
 
 with open(version_file) as version_f:
    version = version_f.read().strip()
@@ -33,7 +41,11 @@ logger = logging.getLogger('pycnv_sum_folder')
 
 
 def get_stations():
-    stations_file = pkg_resources.resource_filename('pycnv', 'stations/iow_stations.yaml')
+    try:
+        with importlib_resources.path('pycnv', 'stations/iow_stations.yaml') as p:
+            stations_file = str(p)
+    except Exception:
+        stations_file = os.path.join(os.path.dirname(__file__), 'stations', 'iow_stations.yaml')
     f_stations = open(stations_file)
     # use safe_load instead load
     stations_yaml = yaml.safe_load(f_stations)
@@ -284,8 +296,12 @@ def main():
             sname_tmp = args.station[0]
         else:
             sname_tmp = None
-        stations_file = pkg_resources.resource_filename('pycnv', 'stations/iow_stations.yaml')
-        print('Stations file:',stations_file)
+        try:
+            with importlib_resources.path('pycnv', 'stations/iow_stations.yaml') as p:
+                stations_file = str(p)
+        except Exception:
+            stations_file = os.path.join(os.path.dirname(__file__), 'stations', 'iow_stations.yaml')
+        print('Stations file:', stations_file)
         f_stations = open(stations_file)
         # use safe_load instead load
         stations_yaml = yaml.safe_load(f_stations)


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/ and https://forum.access-hive.org.au/t/reading-ctd-data-in-analysis-3-26-xx-environments-using-pycnv/6151

Basically, we have a kitchen sink conda environment containing this package. Unfortunately it no longer works because setuptools 82 removes pkg_resources support. 

This PR just migrates from `pkg_resources` to `importlib`